### PR TITLE
Revert "Bump autobahn from 19.1.1 to 20.12.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asgiref==2.3.2
 async-timeout==2.0.1
 attrs==18.2.0
-autobahn==20.12.3
+autobahn==19.1.1
 Automat==0.7.0
 certifi==2019.6.16
 channels==2.1.3


### PR DESCRIPTION
# Description

- Docker-compose file added.
- Setup instruction modified.

# Testing
- None.

Related with ticket: https://trello.com/c/nSv152Ux