### PR TITLE
Revert "Bump django from 1.11.20 to 2.2.27"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ constantly==15.1.0
 contextlib2==0.5.5
 coverage==4.5.3
 daphne==2.2.5
-Django==2.2.27
+Django==1.11.20
 django-appconf==1.0.2
 django-compressor==1.5
 django-cronjobs==0.2.3


### PR DESCRIPTION
# Description

- Docker-compose file added.
- Setup instruction modified.

# Testing
- None.

Related with ticket: https://trello.com/c/nSv152Ux